### PR TITLE
Match borica payments by cardId first and then username

### DIFF
--- a/__tests__/classes/IntegrationTool.js
+++ b/__tests__/classes/IntegrationTool.js
@@ -59,13 +59,18 @@ describe('integration', () => {
 
     describe('fetchPaymentMembers', () => {
       test('should resolve paymentId', async () => {
-        const [{ username }] = await ah.api.integration.fetchPaymentMembers(['1286'])
-        expect(username).toEqual('user1')
+        const [{ username }] = await ah.api.integration.fetchPaymentMembers(['1385'])
+        expect(username).toEqual('user3')
       })
 
       test('should skip invalid paymentId', async () => {
         const res = await ah.api.integration.fetchPaymentMembers(['NO ID'])
         expect(res).toEqual([])
+      })
+
+      test('should return card', async () => {
+        const [{ card }] = await ah.api.integration.fetchPaymentMembers(['1286'])
+        expect(card).toEqual('123456')
       })
     })
 

--- a/__tests__/classes/__snapshots__/IntegrationTool.js.snap
+++ b/__tests__/classes/__snapshots__/IntegrationTool.js.snap
@@ -8,6 +8,7 @@ Object {
   "payments": Array [
     Object {
       "amount": 20,
+      "cardId": "123456",
       "info": "MEM_1286/15510496/10",
       "membershipType": "group",
       "paymentDate": 2015-04-09T07:19:16.000Z,
@@ -18,6 +19,7 @@ Object {
     },
     Object {
       "amount": 10,
+      "cardId": "",
       "info": "DMEM_1385/15510496/10",
       "membershipType": "regular",
       "paymentDate": 2015-10-26T18:21:25.000Z,

--- a/__tests__/tasks/ImportBoricaPayments.js
+++ b/__tests__/tasks/ImportBoricaPayments.js
@@ -17,7 +17,7 @@ describe('task ImportBoricaPayments', () => {
 
   beforeEach(async () => {
     await ah.api.models.payment.truncate({ force: true })
-    member1 = await ah.api.models.member.create(generateMember({ username: 'user1' }))
+    member1 = await ah.api.models.member.create(generateMember({ username: 'user3' }))
   })
 
   afterEach(async () => {
@@ -42,6 +42,13 @@ describe('task ImportBoricaPayments', () => {
     await run()
     const countAfter = await ah.api.models.payment.count()
     expect(countAfter).toEqual(countBefore)
+  })
+
+  test('should match members by card id', async () => {
+    const member = await ah.api.models.member.create(generateMember({ cardId: '123456' }))
+    await run()
+    const payments = await member.getPayments()
+    expect(payments).toHaveLength(1)
   })
 
   test('should schedule membership recalculation', async () => {

--- a/test/files/bspborg.sql
+++ b/test/files/bspborg.sql
@@ -45,7 +45,7 @@ CREATE TABLE `members` (
 --
 
 INSERT INTO `members` (`id`, `name`, `surname`, `family`, `egn`, `username`, `password`, `city`, `postcode`, `neighborhood`, `street`, `number`, `block`, `doorway`, `floor`, `apartment`, `home_phone`, `work_phone`, `mobile`, `email`, `website`, `date_created`, `type`, `lost_code`, `lost_date`, `parent_id`, `card`, `card_expiry`, `family_members`, `country`) VALUES
-(1, 'Тестов', 'Потребител', NULL, NULL, 'user1', NULL, NULL, NULL, '', NULL, NULL, 0, '', 0, 0, 0, 0, 0, NULL, '', '2018-09-17 00:00:00', 1, NULL, NULL, NULL, '', NULL, 1, NULL),
+(1, 'Тестов', 'Потребител', NULL, NULL, 'user1', NULL, NULL, NULL, '', NULL, NULL, 0, '', 0, 0, 0, 0, 0, NULL, '', '2018-09-17 00:00:00', 1, NULL, NULL, NULL, '123456', NULL, 1, NULL),
 (2, 'Тестер', '', 'Тестер', NULL, 'user2', NULL, NULL, NULL, '', NULL, NULL, 0, '', 0, 0, 0, 0, 0, NULL, '', '2018-09-17 00:00:00', 1, NULL, NULL, NULL, '', NULL, 1, NULL),
 (3, 'Testing', '', 'User', NULL, 'user3', NULL, NULL, NULL, '', NULL, NULL, 0, '', 0, 0, 0, 0, 0, NULL, '', '2018-09-17 00:00:00', 1, NULL, NULL, NULL, '', NULL, 1, NULL);
 


### PR DESCRIPTION
Members are creating multiple accounts on bspb.org and simple username is not enough to import all appropriate payments. CardId is the single unique identifier that members are given and should be used to primarily identify payments. That is why this change tries to match payments by cardId first and if no matching member can be found then it tries using username, which is provided by administrator.
